### PR TITLE
Add counting leaderboard

### DIFF
--- a/pkg/jia/handlers.go
+++ b/pkg/jia/handlers.go
@@ -90,7 +90,7 @@ func onMessage(slackClient *slack.Client, event *slackevents.MessageEvent) {
 	month := now.Month()
 
 	// Increment the person's monthly count
-	redisClient.Incr(fmt.Sprintf("leaderboard:%d-%d:%s", month, year, event.User))
+	redisClient.Incr(fmt.Sprintf("leaderboard:%d-%d:%s", year, month, event.User))
 }
 
 func HandleLeaderboardSlashCommand(w http.ResponseWriter, r *http.Request) {
@@ -99,13 +99,13 @@ func HandleLeaderboardSlashCommand(w http.ResponseWriter, r *http.Request) {
 	year := now.Year()
 	month := now.Month()
 
-	scan := redisClient.Scan(0, fmt.Sprintf("leaderboard:%d-%d:*", month, year), 10)
+	scan := redisClient.Scan(0, fmt.Sprintf("leaderboard:%d-%d:*", year, month), 10)
 	if scan.Err() != nil {
 		w.Write([]byte("Something went wrong while loading the leaderboard :cry: Please try again later!"))
 		return
 	}
 
-	scan_iterator := scan.Iterator()
+	scanIterator := scan.Iterator()
 
 	type Entry struct {
 		Number int
@@ -114,16 +114,16 @@ func HandleLeaderboardSlashCommand(w http.ResponseWriter, r *http.Request) {
 
 	entries := []Entry{}
 
-	for scan_iterator.Next() {
-		entry := redisClient.Get(scan_iterator.Val())
-		entry_int, err := entry.Int()
+	for scanIterator.Next() {
+		entry := redisClient.Get(scanIterator.Val())
+		entryInt, err := entry.Int()
 		if err != nil {
 			return
 		}
 
-		if user, ok := parseLeaderboardEntry(scan_iterator.Val()); ok {
+		if user, ok := parseLeaderboardEntry(scanIterator.Val()); ok {
 			entries = append(entries, Entry{
-				Number: entry_int,
+				Number: entryInt,
 				User:   user,
 			})
 		}

--- a/pkg/jia/handlers.go
+++ b/pkg/jia/handlers.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -14,7 +15,6 @@ func HandleInnerEvent(slackClient *slack.Client, innerEvent *slackevents.EventsA
 	switch e := innerEvent.Data.(type) {
 	case *slackevents.MessageEvent:
 		onMessage(slackClient, e)
-		break
 	}
 }
 
@@ -80,4 +80,12 @@ func onMessage(slackClient *slack.Client, event *slackevents.MessageEvent) {
 	// Finally!
 	redisClient.Set("last_valid_number", matchedNumber, 0)
 	redisClient.Set("last_sender_id", event.User, 0)
+
+	// Get the current month/year in UTC
+	now := time.Now().UTC()
+	year := now.Year()
+	month := now.Month()
+
+	// Increment the person's monthly count
+	redisClient.Incr(fmt.Sprintf("%d-%d:%s", month, year, event.User))
 }

--- a/pkg/jia/handlers.go
+++ b/pkg/jia/handlers.go
@@ -147,8 +147,8 @@ func HandleLeaderboardSlashCommand(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, _ := json.Marshal(map[string]interface{}{
-		"blocks":       blocks,
-		"respose_type": "in_channel",
+		"blocks":        blocks,
+		"response_type": "in_channel",
 	})
 
 	w.Header().Add("Content-Type", "application/json")

--- a/pkg/jia/server.go
+++ b/pkg/jia/server.go
@@ -35,6 +35,7 @@ func StartServer(config *Config) {
 
 	// Start receiving events
 	http.HandleFunc("/slack/events", handleSlackEvents)
+	http.HandleFunc("/slack/leaderboard", HandleLeaderboardSlashCommand)
 	http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", config.Port), nil)
 }
 


### PR DESCRIPTION
This PR adds a slash command (available at http://server/slack/leaderboard) that shows monthly counting stats!